### PR TITLE
Add character quoting to HTMLFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Pretty output:
     <td>faker</td>
     <td>1.6.6</td>
     <td>1.6.5</td>
-    <td>~> 1.4</td>
+    <td>~&gt; 1.4</td>
     <td>development, test</td>
   </tr>
   <tr>

--- a/lib/bundle_outdated_formatter/formatter/html_formatter.rb
+++ b/lib/bundle_outdated_formatter/formatter/html_formatter.rb
@@ -1,6 +1,5 @@
 require 'rexml/document'
 require 'bundle_outdated_formatter/formatter'
-require 'cgi'
 
 module BundleOutdatedFormatter
   # Formatter for HTML
@@ -39,7 +38,7 @@ module BundleOutdatedFormatter
       elements = @root.add_element(REXML::Element.new('tr'))
 
       COLUMNS.each do |column|
-        escaped_text = CGI.escapeHTML(gem[column])
+        escaped_text = REXML::Text.new(gem[column], false, nil, false)
         elements.add_element('td').add_text(escaped_text)
       end
     end

--- a/lib/bundle_outdated_formatter/formatter/html_formatter.rb
+++ b/lib/bundle_outdated_formatter/formatter/html_formatter.rb
@@ -1,5 +1,6 @@
 require 'rexml/document'
 require 'bundle_outdated_formatter/formatter'
+require 'cgi'
 
 module BundleOutdatedFormatter
   # Formatter for HTML
@@ -38,7 +39,8 @@ module BundleOutdatedFormatter
       elements = @root.add_element(REXML::Element.new('tr'))
 
       COLUMNS.each do |column|
-        elements.add_element('td').add_text(gem[column])
+        escaped_text = CGI.escapeHTML(gem[column])
+        elements.add_element('td').add_text(escaped_text)
       end
     end
   end

--- a/spec/bundle_outdated_formatter/cli_spec.rb
+++ b/spec/bundle_outdated_formatter/cli_spec.rb
@@ -145,7 +145,7 @@ Outdated gems included in the bundle:
 
   let(:stdout_html) do
     <<-EOS
-<table><tr><th>gem</th><th>newest</th><th>installed</th><th>requested</th><th>groups</th></tr><tr><td>faker</td><td>1.6.6</td><td>1.6.5</td><td>~> 1.4</td><td>development, test</td></tr><tr><td>hashie</td><td>3.4.6</td><td>1.2.0</td><td>= 1.2.0</td><td>default</td></tr><tr><td>headless</td><td>2.3.1</td><td>2.2.3</td><td></td><td></td></tr></table>
+<table><tr><th>gem</th><th>newest</th><th>installed</th><th>requested</th><th>groups</th></tr><tr><td>faker</td><td>1.6.6</td><td>1.6.5</td><td>~&gt; 1.4</td><td>development, test</td></tr><tr><td>hashie</td><td>3.4.6</td><td>1.2.0</td><td>= 1.2.0</td><td>default</td></tr><tr><td>headless</td><td>2.3.1</td><td>2.2.3</td><td></td><td></td></tr></table>
     EOS
   end
 
@@ -163,7 +163,7 @@ Outdated gems included in the bundle:
     <td>faker</td>
     <td>1.6.6</td>
     <td>1.6.5</td>
-    <td>~> 1.4</td>
+    <td>~&gt; 1.4</td>
     <td>development, test</td>
   </tr>
   <tr>

--- a/spec/bundle_outdated_formatter/formatter/html_formatter_spec.rb
+++ b/spec/bundle_outdated_formatter/formatter/html_formatter_spec.rb
@@ -24,13 +24,20 @@ RSpec.describe BundleOutdatedFormatter::HTMLFormatter do
         'installed' => '2.2.3',
         'requested' => '',
         'groups'    => ''
+      },
+      {
+        'gem'       => 'rbnacl',
+        'newest'    => '5.0.0',
+        'installed' => '4.0.2',
+        'requested' => '>= 3.2, < 5.0',
+        'groups'    => ''
       }
     ]
   end
 
   let(:text_html) do
     <<-EOS.chomp
-<table><tr><th>gem</th><th>newest</th><th>installed</th><th>requested</th><th>groups</th></tr><tr><td>faker</td><td>1.6.6</td><td>1.6.5</td><td>~> 1.4</td><td>development, test</td></tr><tr><td>hashie</td><td>3.4.6</td><td>1.2.0</td><td>= 1.2.0</td><td>default</td></tr><tr><td>headless</td><td>2.3.1</td><td>2.2.3</td><td></td><td></td></tr></table>
+<table><tr><th>gem</th><th>newest</th><th>installed</th><th>requested</th><th>groups</th></tr><tr><td>faker</td><td>1.6.6</td><td>1.6.5</td><td>~&gt; 1.4</td><td>development, test</td></tr><tr><td>hashie</td><td>3.4.6</td><td>1.2.0</td><td>= 1.2.0</td><td>default</td></tr><tr><td>headless</td><td>2.3.1</td><td>2.2.3</td><td></td><td></td></tr><tr><td>rbnacl</td><td>5.0.0</td><td>4.0.2</td><td>&gt;= 3.2, &lt; 5.0</td><td></td></tr></table>
     EOS
   end
 
@@ -48,7 +55,7 @@ RSpec.describe BundleOutdatedFormatter::HTMLFormatter do
     <td>faker</td>
     <td>1.6.6</td>
     <td>1.6.5</td>
-    <td>~> 1.4</td>
+    <td>~&gt; 1.4</td>
     <td>development, test</td>
   </tr>
   <tr>
@@ -63,6 +70,13 @@ RSpec.describe BundleOutdatedFormatter::HTMLFormatter do
     <td>2.3.1</td>
     <td>2.2.3</td>
     <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>rbnacl</td>
+    <td>5.0.0</td>
+    <td>4.0.2</td>
+    <td>&gt;= 3.2, &lt; 5.0</td>
     <td></td>
   </tr>
 </table>


### PR DESCRIPTION
Hi! Thank you for a useful gem 😆 

I've got an error when running a command like `bundle outdated | bof --format html` with `Gemfile` includes the line below.

```ruby
gem 'rbnacl', '>= 3.2', '< 5.0'
```

```sh
Traceback (most recent call last):
        19: from /Users/me/dev/src/github.com/username/projectname/.bundle/bin/bof:29:in `<main>'
        18: from /Users/me/dev/src/github.com/username/projectname/.bundle/bin/bof:29:in `load'
        17: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/bundle_outdated_formatter-0.4.0/exe/bof:5:in `<top (required)>'
        16: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
        15: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
        14: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
        13: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
        12: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/bundle_outdated_formatter-0.4.0/lib/bundle_outdated_formatter/cli.rb:38:in `output'
        11: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/bundle_outdated_formatter-0.4.0/lib/bundle_outdated_formatter/formatter/html_formatter.rb:18:in `convert'
        10: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/bundle_outdated_formatter-0.4.0/lib/bundle_outdated_formatter/formatter/html_formatter.rb:18:in `each'
         9: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/bundle_outdated_formatter-0.4.0/lib/bundle_outdated_formatter/formatter/html_formatter.rb:19:in `block in convert'
         8: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/bundle_outdated_formatter-0.4.0/lib/bundle_outdated_formatter/formatter/html_formatter.rb:40:in `add_data_row'
         7: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/bundle_outdated_formatter-0.4.0/lib/bundle_outdated_formatter/formatter/html_formatter.rb:40:in `each'
         6: from /Users/me/dev/src/github.com/username/projectname/vendor/bundle/ruby/2.5.0/gems/bundle_outdated_formatter-0.4.0/lib/bundle_outdated_formatter/formatter/html_formatter.rb:41:in `block in add_data_row'
         5: from /usr/local/var/rbenv/versions/2.5.1/lib/ruby/2.5.0/rexml/element.rb:529:in `add_text'
         4: from /usr/local/var/rbenv/versions/2.5.1/lib/ruby/2.5.0/rexml/element.rb:529:in `new'
         3: from /usr/local/var/rbenv/versions/2.5.1/lib/ruby/2.5.0/rexml/text.rb:121:in `initialize'
         2: from /usr/local/var/rbenv/versions/2.5.1/lib/ruby/2.5.0/rexml/text.rb:154:in `check'
         1: from /usr/local/var/rbenv/versions/2.5.1/lib/ruby/2.5.0/rexml/text.rb:154:in `scan'
/usr/local/var/rbenv/versions/2.5.1/lib/ruby/2.5.0/rexml/text.rb:156:in `block in check': Illegal character '<' in raw string "< 5.0, >= 3.2" (RuntimeError)
```

I think the output should be quoted on `HTMLFormater`.
Please check my changes and merge them if you can.