### PR TITLE
Refine regexp for new bundle-outdated format

### DIFF
--- a/lib/bundle_outdated_formatter/formatter.rb
+++ b/lib/bundle_outdated_formatter/formatter.rb
@@ -7,7 +7,7 @@ module BundleOutdatedFormatter
     NEWEST_REGEXP    = /newest (?<newest>[\d\.]+)/.freeze
     INSTALLED_REGEXP = /installed (?<installed>[\d\.]+)/.freeze
     REQUESTED_REGEXP = /requested (?<requested>.+)\)/.freeze
-    GROUPS_REGEXP    = /in groups "(?<groups>.+)"/.freeze
+    GROUPS_REGEXP    = /in groups? "(?<groups>.+)"/.freeze
 
     def initialize(options)
       @pretty = options[:pretty]

--- a/spec/bundle_outdated_formatter/formatter_spec.rb
+++ b/spec/bundle_outdated_formatter/formatter_spec.rb
@@ -13,7 +13,7 @@ Resolving dependencies...
 
 Outdated gems included in the bundle:
   * faker (newest 1.6.6, installed 1.6.5, requested ~> 1.4) in groups "development, test"
-  * hashie (newest 3.4.6, installed 1.2.0, requested = 1.2.0) in groups "default"
+  * hashie (newest 3.4.6, installed 1.2.0, requested = 1.2.0) in group "default"
   * headless (newest 2.3.1, installed 2.2.3)
     EOS
   end


### PR DESCRIPTION
I found the output format of `bundle outdated` changed a little:

```
# before
* hashie (newest 3.4.6, installed 1.2.0, requested = 1.2.0) in groups "default"

# now (Bundler 2.1.4)
* hashie (newest 3.4.6, installed 1.2.0, requested = 1.2.0) in group "default"
```

So `GROUPS_REGEXP` needs to be updated.